### PR TITLE
bug: #121 ensure correct route name for small video link

### DIFF
--- a/components/SmallVideo.vue
+++ b/components/SmallVideo.vue
@@ -20,7 +20,7 @@ export default {
   computed:{
     videoLink () {
       return this.$router.resolve({
-        name: this.$route.name,
+        name: 'category-name-video',
         params: {
           ...this.$route.params,
           video: this.url


### PR DESCRIPTION
## Your checklist for this pull request

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Resolved a case when route name was incorrect, due to `small-video` component showing on both service and single video page.



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Video link is resolved correctly for thumbnail preview

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: #121 
