### PR TITLE
bug: #124 fix iot icon name casing

### DIFF
--- a/static/services.json
+++ b/static/services.json
@@ -1302,8 +1302,8 @@
     "info": {
       "name": "Internet Of Things",
       "description": "All your hardware maanged in one place.",
-      "img": "/Internet Of Things/Internet-of-Things.svg",
-      "imgPng": "/Internet Of Things/Internet-of-Things.png"
+      "img": "/Internet of Things/Internet-of-Things.svg",
+      "imgPng": "/Internet of Things/Internet-of-Things.png"
     },
     "data": [
       {


### PR DESCRIPTION
## Your checklist for this pull request

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
"Internet Of Things" service icon path did not match updated folder name that contains the icon

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Icon path has been updated for both SVG and PNG icons for Internet of Things service.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: #124 
