### PR TITLE
bug: #126 ensure consistency of ad card dimensions

### DIFF
--- a/pages/_category/_name/_video.vue
+++ b/pages/_category/_name/_video.vue
@@ -16,7 +16,7 @@
           class="v-category-video__video"
         />
 
-        <p>{{description}}</p>
+        <p>{{ description }}</p>
       </b-col>
       <b-col
           sm="12"
@@ -26,10 +26,13 @@
       >
         <div class="my-xs-4 my-xs-4 d-flex flex-column v-category-video__column-ad">
           <Ad :random="true"></Ad>
-          <div style="height:190px" class="mt-2 grey-box"></div>
+          <div
+              class="mt-2 grey-box v-category-video__column-ad__bottom"
+          />
         </div>
       </b-col>
-      <b-col md="3">
+
+      <b-col>
         <div style="width:100%;height:100%" class="my-xs-4 grey-box"></div>
       </b-col>
     </b-row>
@@ -269,14 +272,23 @@ ul{
   padding:0px
 }
 
-.grey-box{
-  background-color:#e9ecef;
-  border-radius:0.25rem;
+.grey-box {
+  background-color: #e9ecef;
+  border-radius: 0.25rem;
+}
+
+.v-category-video__column-ad__bottom {
+  height: 190px;
 }
 
 @media all and (min-width: 992px) {
   .v-category-video__column-ad {
-    max-width: 290px;
+    max-width: 270px;
+    height: 100%;
+  }
+
+  .v-category-video__column-ad__bottom {
+    height: 100%;
   }
 }
 

--- a/pages/_category/_name/index.vue
+++ b/pages/_category/_name/index.vue
@@ -17,7 +17,7 @@
         >
         </main-video>
         <p>
-          {{description}}
+          {{ description }}
         </p>
       </b-col>
       <b-col
@@ -30,9 +30,10 @@
             class="my-xs-4 d-flex flex-column v-category-name__column-ad"
         >
           <Ad :random="true"></Ad>
-          <div style="height:190px" class="mt-3 grey-box"></div>
+          <div class="mt-3 grey-box v-category-name__column-ad__bottom" />
         </div>
       </b-col>
+
       <b-col>
         <div style="width:100%;height:100%" class="my-xs-4 grey-box"></div>
       </b-col>
@@ -220,14 +221,23 @@ ul{
   padding:0px
 }
 
-.grey-box{
+.grey-box {
   background-color:#e9ecef;
   border-radius:0.25rem;
 }
 
+.v-category-name__column-ad__bottom {
+  height: 190px;
+}
+
 @media all and (min-width: 992px) {
   .v-category-name__column-ad {
-    max-width: 290px;
+    max-width: 270px;
+    height: 100%;
+  }
+
+  .v-category-name__column-ad__bottom {
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
## Your checklist for this pull request

🚨 Make sure you adhered to our guidelines.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Ads on video and category page now have the same dimensions as on other pages

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ad card width & height are the same across pages
- Gray box below the ad card now stretches down the container to take free space

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #126 