### PR TITLE
feat: #134 ensure trailing slash in sitemap urls

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -70,6 +70,7 @@ export default {
   sitemap:{
     path: 'sitemap.xml',
     hostname: 'https://awsvideocatalog.com',
+    trailingSlash: true,
     routes (){
       return appPagesUrls
     }


### PR DESCRIPTION
## Your checklist for this pull request

🚨 Make sure you adhered to our guidelines.

- **DO** keep pull requests small so they can be easily reviewed.
- **DO** assigne a reviewer if you are not the mantainer.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Using `@nuxtjs/sitemap` module configuration option `trailingSlash` set to `true`, sitemap location URLs now ensure that trailing slash is present for every locaton


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Trailing slash is not present in every location of application sitemap

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #134 
