### PR TITLE
bug: #154 fix appstream category not found error

### DIFF
--- a/static/service_server.js
+++ b/static/service_server.js
@@ -315,7 +315,7 @@ const templates = {
   amazon_chime,
   workmail,
   workspaces,
-  appstream_2,
+  'appstream_2.0': appstream_2,
   workdocs,
   worklink,
   iot_core,


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Resolved invalid category `Appstream 2.0` name mapping when loading service page.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `/end_user_computing/appstream_2.0/` page opens as expected
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #154 
