### PR TITLE
feat: #151 create service page video grid

### DIFF
--- a/components/BreadCrumb.vue
+++ b/components/BreadCrumb.vue
@@ -53,6 +53,12 @@ export default {
             }).href
           })
         }
+
+        if (params.video) {
+          crumbs.push({
+            text: params.video
+          })
+        }
       }
 
       return crumbs

--- a/components/general/VideoPreview/index.vue
+++ b/components/general/VideoPreview/index.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="video-preview__container">
+    <router-link
+      :to="videoRoute"
+      class="video-preview__preview"
+    >
+      <img
+        :src="video.thumbnail"
+        :alt="video.title"
+        :title="video.title"
+        class="video-preview__image"
+      >
+    </router-link>
+
+    <p>{{ titleTruncated }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'VideoPreview',
+
+  props: {
+    video: {
+      type: Object,
+      default: () => ({}),
+      required: true
+    }
+  },
+
+  computed: {
+    videoRoute () {
+      return {
+        name: 'category-name-video',
+        params: {
+          ...this.$route.params,
+          video: this.video.id
+        }
+      }
+    },
+
+    titleTruncated () {
+      if (this.video.title.length <= 65) {
+        return this.video.title
+      }
+      return this.video.title.slice(0, 65) + '...'
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.video-preview {
+  &__container {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  &__preview {
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+
+  &__image {
+    width: 100%;
+  }
+}
+</style>

--- a/pages/_category/_name/index.vue
+++ b/pages/_category/_name/index.vue
@@ -2,19 +2,21 @@
   <div class="listing-container mx-5">
     <bread-crumb/>
 
-    <section-video-player
-      :video="main_video"
-      :description="description"
-    />
-
     <hr/>
     <b-row v-for="data in data_by_years" :key="data.year">
       <h3 style="padding-left:15px;width:100vw;">{{data.year}}</h3>
-      <div style="padding-left:15px" v-for="(video,i) in data.videos" :key="'video_'+i">
-        <small-video
+      <b-col
+        sm="6"
+        md="4"
+        lg="3"
+        xl="2"
+        v-for="(video,i) in data.videos"
+        :key="'video_'+i"
+      >
+        <video-preview
           :video="video"
         />
-      </div>
+      </b-col>
     </b-row>
     <hr class="height:1px"></hr>
   </div>
@@ -28,8 +30,8 @@ import getService from '~/static/service_server.js'
 import get_actual_details from '~/custom_modules/get_actual_details'
 import SmallVideo from '~/components/SmallVideo.vue'
 import BreadCrumb from '~/components/BreadCrumb.vue'
-import SectionVideoPlayer from '~/components/sections/video/SectionVideoPlayer'
 import { formatVideo } from '~/utils/videos'
+import VideoPreview from '@/components/general/VideoPreview/index'
 
 // HELPER FUNCTIONS
 
@@ -43,7 +45,7 @@ function remove(array, element) {
 export default {
   layout: "default",
   components:{
-    SectionVideoPlayer,
+    VideoPreview,
     SmallVideo,
     BreadCrumb
   },
@@ -84,13 +86,11 @@ export default {
     //  4.  If there isn't a video id given in query params, return the first
     //      video from sorted dataset.
     //
-    main_video = sorted_data[0]
 
     return{
       name: route.params.name,
       service_data: sorted_data,
       title: text,
-      main_video: main_video,
       category_name: actual_details.category_details.name,
       description: actual_details.service_details.description,
       img: actual_details.service_details.img,


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
This PR changes layout of service page. Main video player has been removed from service page to display larger grid of video previews.


## What is the new behavior?
- Remove `SectionVideoPlayer` from service page
- Create `VideoPreview` component and apply on service page
- `VideoPreview` component uses `router-link` for app navigation without page refresh
- Service video grid is responsive and preview sizes change depending on device screen width.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #151 