### PR TITLE
feat: #131 expand card text overflow on hover, add shadows

### DIFF
--- a/components/Listing.vue
+++ b/components/Listing.vue
@@ -9,39 +9,32 @@
       >
         <ad
           :ad-order="random_ad_order[0]"
-          class="my-2 service-listings__card"
+          class="service-listings__card"
           :height="'400px'"
         />
       </b-col>
+
       <b-col
-        v-for="(item,idx) in items"
-        :key="`item_${idx}`"
         sm="6"
         md="4"
         lg="3"
         xl="2"
+        v-for="(service, idx) in items"
+        :key="idx"
+        class="service-listings__card"
       >
-        <nuxt-link class="service my-2" :to="links[idx]+'/'" append component="div">
-          <b-card
-            :title="item.name"
-            :img-src="item.img ? '/images/aws/svg/SVG Light'+item.img : '/images/aws/svg/SVG Light/_Group Icons/AWS-Cloud-alt_light-bg.svg'"
-            img-alt="Image"
-            img-top
-            class="service-listings__card"
-          >
-            <b-card-text>
-              {{item.description}}
-            </b-card-text>
-          </b-card>
-        </nuxt-link>
+        <service-card
+          :service="service"
+        />
       </b-col>
     </b-row>
   </div>
 </template>
 
 <script>
-  import Ad from '~/components/Ad.vue'
-  import ads from '~/static/products/index.json'
+import Ad from '~/components/Ad.vue'
+import ads from '~/static/products/index.json'
+import ServiceCard from '~/components/sections/services/ServiceCard/index'
 
   //
   //  1.  Defining a new property which would shuffle an array
@@ -71,8 +64,11 @@
 //  This component will render a tree-like view when a JSON is given
 //
 export default {
+  name: 'Listing',
+
   components:{
-    Ad
+    Ad,
+    ServiceCard
   },
   props:{
     items:{
@@ -131,12 +127,18 @@ export default {
 .service-listings__card {
   height: auto;
   width: 100%;
-  overflow: hidden;
+  margin-bottom: 1rem;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 768px) {
   .service-listings__card {
     height: 400px;
+  }
+}
+
+@media (min-width: 1600px) {
+  .service-listings__card {
+    height: 420px;
   }
 }
 </style>

--- a/components/sections/services/ServiceCard/index.vue
+++ b/components/sections/services/ServiceCard/index.vue
@@ -1,0 +1,149 @@
+<template>
+  <router-link
+    :to="serviceRouteAppendUrl"
+    append
+    class="service-card__container"
+  >
+    <div
+      class="service-card__inner"
+      @mouseenter="onCardMouseEnter"
+      @mouseleave="onCardMouseLeave"
+    >
+      <img
+        :src="serviceImage"
+        :alt="service.name"
+        class="service-card__image"
+      >
+
+      <div class="service-card__body">
+        <h4 class="service-card__title">
+          {{ service.name }}
+        </h4>
+
+        <div
+          class="service-card__text"
+        >
+          {{ service.description }}
+        </div>
+      </div>
+    </div>
+  </router-link>
+</template>
+
+<script>
+export default {
+  name: 'ServiceCard',
+
+  props: {
+    service: {
+      type: Object,
+      default: () => ({}),
+      required: true
+    }
+  },
+
+  computed: {
+    serviceImage () {
+      return this.service.img ? `/images/aws/svg/SVG Light${this.service.img}` : '/images/aws/svg/SVG Light/_Group Icons/AWS-Cloud-alt_light-bg.svg'
+    },
+
+    serviceRouteAppendUrl () {
+      return this.service.name.split(' ').join('_').toLowerCase()
+    }
+  },
+
+  methods: {
+    checkShouldExpandCard () {
+      return window.matchMedia('(min-width: 768px)').matches
+    },
+
+    onCardMouseEnter (event) {
+      if (!this.checkShouldExpandCard()) {
+        return
+      }
+
+      const targetEl = event.target
+
+      if (!targetEl) {
+        return
+      }
+
+      targetEl.style.height = targetEl.scrollHeight?.toString() + 'px'
+      targetEl.style.zIndex = '10'
+    },
+
+    onCardMouseLeave (event) {
+      if (!this.checkShouldExpandCard()) {
+        return
+      }
+
+      const TRANSITION_DURATION = 250
+      const targetEl = event.target
+
+      if (!targetEl) {
+        return
+      }
+
+      targetEl.style.height = ''
+      setTimeout(() => {
+        targetEl.style.zIndex = ''
+      }, TRANSITION_DURATION)
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.service-card {
+  &__container {
+    position: relative;
+    display: block;
+  }
+
+  &__inner {
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    color: rgb(33, 37, 41);
+    background-clip: border-box;
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
+    transition: height 0.2s ease-in-out, box-shadow 0.3s ease-in-out;
+    overflow: hidden;
+    background-color: #fff;
+
+    &:hover {
+      text-decoration: none;
+      color: rgb(33, 37, 41);
+    }
+  }
+
+  &__image {
+    width: 100%;
+  }
+
+  &__body {
+    padding: 0.45rem 1.25rem;
+  }
+
+  &__title {
+    margin-bottom: 0.75rem;
+  }
+
+  @media (min-width: 768px) {
+    &__container {
+      height: 100%;
+    }
+
+    &__inner {
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      &:hover {
+        box-shadow: 1px 8px 25px -7px rgba(158,158,158,1);
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!-- Please give a general description about the new code. -->
This PR includes new service card component. In order to add functionality to expand card content on hover, I've decided to refactor the card without usage of Bootstrap, as it was posing challenges in feature implementation. Now card will expand on hover if text overflow the card. Not that overflow text is cut in the middle on purpose to give users the idea of hidden content.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When card is hovered a shadow appears
- When card is hovered and it's text does not fit card height, it will expand to show full card text

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #131 
