### PR TITLE
bug: #185 exclude videos without uls from generation

### DIFF
--- a/custom_modules/sitemap-generate.js
+++ b/custom_modules/sitemap-generate.js
@@ -29,9 +29,13 @@ function loadStaticJson (path) {
  */
 function generateServiceVideosPaths (videosData, servicePath) {
   return videosData.reduce((result, videoData) => {
-    const videoId = getYoutubeIdFromVideoLink(videoData.url)
+    if (videoData.url) {
+      const videoId = getYoutubeIdFromVideoLink(videoData.url)
 
-    result.push(`${servicePath}/${videoId}`)
+      if (videoId) {
+        result.push(`${servicePath}/${videoId}`)
+      }
+    }
 
     return result
   }, [])


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!-- Please give a general description about the new code. -->
Videos without URLs are not skipped in routes and sitemap generation.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No errors are thrown during generation

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #185 