### PR TITLE
Vv/#172 add services listing ad in the end

### DIFF
--- a/components/Listing.vue
+++ b/components/Listing.vue
@@ -121,8 +121,8 @@ export default {
   &__container {
     display: grid;
     grid-template-columns: 1fr;
-    grid-column-gap: 1rem;
-    grid-row-gap: 1rem;
+    grid-column-gap: 30px;
+    grid-row-gap: 30px;
   }
 
   &__card {

--- a/components/Listing.vue
+++ b/components/Listing.vue
@@ -18,6 +18,12 @@
         :service="service"
       />
     </div>
+
+    <div class="service-listings__card">
+      <ad
+        :ad-order="random_ad_order[1]"
+      />
+    </div>
   </div>
 </template>
 

--- a/components/Listing.vue
+++ b/components/Listing.vue
@@ -115,8 +115,8 @@ export default {
   &__container {
     display: grid;
     grid-template-columns: 1fr;
-    grid-column-gap: 30px;
-    grid-row-gap: 30px;
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem;
   }
 
   &__card {


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!-- Please give a general description about the new code. -->
Second ad card is displayed in the end of services list and contains a random ad, but is always different from the first one.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Second ad card added to the end of services list

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #172
