### PR TITLE
bug: #197 fix ads contents mismatch

### DIFF
--- a/components/Ad.vue
+++ b/components/Ad.vue
@@ -36,7 +36,7 @@ export default {
   props:{
     adOrder:{
       type:Number,
-      required:false
+      default: Math.floor(Math.random() * ads.length)
     },
     height:{
       type:String,
@@ -51,26 +51,14 @@ export default {
       required:false
     }
   },
-  computed:{
-    adObject: function(){
-      //
-      //  1.  Return a random ad if random prop is passed True with Ad object
-      //
-      let random = this.$props.random || false
-      if(random)
-      {
-        //
-        //  1.  If random prop is passed True, pick a random integer
-        //      from 0 to length of ads json file.
-        //
-        let random_integer = Math.floor(Math.random() * ads.length);
-        return ads[random_integer]
-      }else
-      {
-        return ads[this.$props.adOrder]
-      }
-    },
 
+  data () {
+    return {
+      adObject: ads[this.adOrder]
+    }
+  },
+
+  computed:{
     classes: function(){
       return {
         width: this.$props.width ? this.$props.width : '100%',

--- a/components/Listing.vue
+++ b/components/Listing.vue
@@ -4,7 +4,7 @@
   >
     <div class="service-listings__card">
       <ad
-        :ad-order="random_ad_order[0]"
+        :ad-order="adsOrder[0]"
       />
     </div>
 
@@ -20,7 +20,7 @@
 
     <div class="service-listings__card">
       <ad
-        :ad-order="random_ad_order[1]"
+        :ad-order="adsOrder[1]"
       />
     </div>
   </div>
@@ -28,33 +28,8 @@
 
 <script>
 import Ad from '~/components/Ad.vue'
-import ads from '~/static/products/index.json'
 import ServiceCard from '~/components/sections/services/ServiceCard/index'
 
-  //
-  //  1.  Defining a new property which would shuffle an array
-  //
-  Object.defineProperty(Array.prototype, 'shuffle', {
-    //
-    //  1.  Return the following value
-    //
-    value: function() {
-      //
-      //  1.  Start by decrementing an i value from the end of array.
-      //
-      for (let i = this.length - 1; i > 0; i--) {
-        //
-        //  1.  Pick a number inside range 0-i
-        //
-        const j = Math.floor(Math.random() * (i + 1));
-        //
-        //  2.  Switch places of element i and element j
-        //
-        [this[i], this[j]] = [this[j], this[i]];
-      }
-      return this;
-    }
-});
 //
 //  This component will render a tree-like view when a JSON is given
 //
@@ -65,17 +40,19 @@ export default {
     Ad,
     ServiceCard
   },
+
   props:{
     items:{
       type:Array,
       required:true,
+    },
+
+    adsOrder: {
+      type: Array,
+      required: true
     }
   },
-  data(){
-    return{
-      ads:ads
-    }
-  },
+
   computed:{
     links: function(){
       //
@@ -94,17 +71,6 @@ export default {
         links.push(link)
       }
       return links
-    },
-    //
-    //  1.  A function to randomize the ad order.
-    //
-    random_ad_order: function(){
-      //
-      //  1.  Create an array with the same length of ads
-      //      starting from 0.
-      //
-      const arr = [...Array(ads.length).keys()];
-      return arr.shuffle()
     }
   }
 }

--- a/components/sections/video/SectionVideoPlayer.vue
+++ b/components/sections/video/SectionVideoPlayer.vue
@@ -12,7 +12,7 @@
       </div>
 
       <div class="s-video-player__ad-fixed">
-        <Ad :random="true"></Ad>
+        <ad :ad-order="adOrder" />
 
         <div class="s-video-player__ad-fixed__box"/>
       </div>
@@ -44,6 +44,11 @@ export default {
     description: {
       type: String,
       default: ''
+    },
+
+    adOrder: {
+      type: Number,
+      default: 0
     }
   }
 }

--- a/pages/_category/_name/_video.vue
+++ b/pages/_category/_name/_video.vue
@@ -5,6 +5,7 @@
     <section-video-player
       :video="main_video"
       :description="description"
+      :ad-order="adsOrder[0]"
     />
 
     <hr class="mt-0" />
@@ -29,6 +30,8 @@ import { formatVideo } from '~/utils/videos'
 import categories from 'static/database/categories'
 import services from 'static/database/categories/services'
 import { caseTitleToSnake } from '@/utils/text'
+import { arrayOfShuffledRandoms } from '~/utils/lists'
+import ads from '~/static/products'
 
 export default {
   layout: "default",
@@ -89,7 +92,8 @@ export default {
       description: service.description,
       img: service.img,
       imgPng: service.imgPng,
-      service_name: service.name
+      service_name: service.name,
+      adsOrder: arrayOfShuffledRandoms(ads.length)
     }
   },
 

--- a/pages/_category/index.vue
+++ b/pages/_category/index.vue
@@ -3,6 +3,7 @@
     <bread-crumb />
     <listing
       :items="category.services"
+      :ads-order="adsOrder"
     />
     <hr></hr>
   </div>
@@ -14,6 +15,8 @@ import Listing from '~/components/Listing.vue'
 import BreadCrumb from '~/components/BreadCrumb.vue'
 import categories from '~/static/database/categories/index.json'
 import services from '~/static/database/categories/services/index.json'
+import { arrayOfShuffledRandoms } from '~/utils/lists'
+import ads from '~/static/products/index.json'
 
 export default {
   layout: 'default',
@@ -42,6 +45,7 @@ export default {
     }
 
     return {
+      adsOrder: arrayOfShuffledRandoms(ads.length),
       category: {
         ...category,
         services: categoryServices

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,6 +9,7 @@
   <div class="mx-5">
     <listing
       :items="categories"
+      :ads-order="adsOrder"
     />
     <hr></hr>
   </div>
@@ -23,6 +24,8 @@
 import Listing from '~/components/Listing.vue'
 import services from '~/static/database/categories/index.json'
 import ThemeToggle from '~/components/general/ThemeToggle/index'
+import { arrayOfShuffledRandoms } from '~/utils/lists'
+import ads from '~/static/products'
 
 export default {
   layout: "default",
@@ -34,7 +37,8 @@ export default {
 
   asyncData (){
     return {
-      categories: Object.values(services)
+      categories: Object.values(services),
+      adsOrder: arrayOfShuffledRandoms(ads.length)
     }
   },
 

--- a/utils/lists.js
+++ b/utils/lists.js
@@ -1,0 +1,29 @@
+/**
+ * Fisher–Yates Shuffle
+ * https://bost.ocks.org/mike/shuffle/
+ * @param length {Number}
+ * @returns {*[]}
+ */
+export function arrayOfShuffledRandoms (length = 2) {
+  const arrayOfRandoms = [...Array(length).keys()]
+
+  const array = [...arrayOfRandoms]
+  let currentIndex = array.length
+  let temporaryValue = null
+  let randomIndex = null
+
+  // While there remain elements to shuffle...
+  while (0 !== currentIndex) {
+
+    // Pick a remaining element...
+    randomIndex = Math.floor(Math.random() * currentIndex)
+    currentIndex -= 1
+
+    // And swap it with the current element.
+    temporaryValue = array[currentIndex]
+    array[currentIndex] = array[randomIndex]
+    array[randomIndex] = temporaryValue
+  }
+
+  return array
+}


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!-- Please give a general description about the new code. -->
This PR includes a fix for ads content and link mismatch. The issue occurred due to random being calculated separately on client and server. In order to fix it, it was necessary to move random order generation to `asyncData` of each page that includes ads.



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Ads are now displayed correctly - image, title, link is matching `products/index.json`
- Now the same ads are displayed on server and client sides

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #197 
