### PR TITLE
feat: #192 add videos preview duration

### DIFF
--- a/assets/styles/_theme.scss
+++ b/assets/styles/_theme.scss
@@ -1,4 +1,6 @@
 @mixin themeVariablesLight () {
+  --color-white: #fff;
+
   --color-font: #212529;
   --color-font-elevated-02: #6c757d;
   --color-font-link: #007bff;
@@ -8,6 +10,7 @@
   --color-bg-reverse: #121212;
   --color-bg-elevated-01: #fff;
   --color-bg-elevated-02: #e9ecef;
+  --color-bg-overlay: rgba(0, 0, 0, 0.5);
 
   --color-border: rgba(0, 0, 0, 0.125);
 
@@ -15,6 +18,8 @@
 }
 
 @mixin themeVariablesDark () {
+  --color-white: #fff;
+
   --color-font: #fff;
   --color-font-elevated-02: #ddd;
   --color-font-link: #459cff;
@@ -24,6 +29,7 @@
   --color-bg-reverse: #fff;
   --color-bg-elevated-01: #333;
   --color-bg-elevated-02: #444;
+  --color-bg-overlay: rgba(0, 0, 0, 0.5);
 
   --color-border: rgba(255, 255, 255, 0.1);
 

--- a/components/sections/video/VideosListing/VideoPreview/index.vue
+++ b/components/sections/video/VideosListing/VideoPreview/index.vue
@@ -11,6 +11,13 @@
           :title="video.title"
           class="video-preview__thumbnail__image"
         >
+
+        <div
+          v-if="video.formattedDuration"
+          class="video-preview__duration"
+        >
+          {{ video.formattedDuration }}
+        </div>
       </div>
 
       <div class="video-preview__body">
@@ -68,12 +75,27 @@ export default {
   }
 
   &__thumbnail {
+    position: relative;
     width: 100%;
     margin-bottom: 0.5rem;
   }
 
   &__thumbnail__image {
     width: 100%;
+  }
+
+  &__duration {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    min-height: 12px;
+    padding: 2px 4px;
+    display: flex;
+    align-items: center;
+    border-radius: 2px;
+    background-color: var(--color-bg-overlay);
+    color: var(--color-white);
+    font-size: 14px;
   }
 
   &__body {

--- a/utils/videos.js
+++ b/utils/videos.js
@@ -1,3 +1,19 @@
+/**
+ * Format seconds to human readable format without leading zeros
+ * Formatting example:
+ * 124 -> '2:04'
+ * 1000 -> '16:40'
+ * 7123 -> '1:58:43'
+ *
+ * @param seconds {Number}
+ * @returns {string}
+ */
+function formatDuration (seconds) {
+  return new Date(seconds * 1000).toISOString().
+    substr(11, 8).
+    replace(/^[0:]+/, '')
+}
+
 function getYoutubeThumbnailUrlById (videoId) {
   return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
 }
@@ -6,6 +22,7 @@ export function formatVideo (video) {
   const videoId = video.videoId
   return {
     ...video,
-    thumbnail: video.thumbnail || getYoutubeThumbnailUrlById(videoId)
+    thumbnail: video.thumbnail || getYoutubeThumbnailUrlById(videoId),
+    formattedDuration: video.duration ? formatDuration(video.duration) : ''
   }
 }


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!-- Please give a general description about the new code. -->
Video duration is added to each video preview on service and video player page. Duration is displayed in same format as on Youtube and with similar styling to be familiar to users.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Duration time is added to each video preview on service and video player pages

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change etc. -->

**Issue(s) this PR closes**: Closes #192 
