### PR TITLE
Remove duplicate AWS Single Sign On Video

### DIFF
--- a/static/database/categories/services/videos/aws_single_sign-on.json
+++ b/static/database/categories/services/videos/aws_single_sign-on.json
@@ -149,24 +149,6 @@
     },
     {
         "service": "aws_single_sign-on",
-        "videoId": "y_n9xN5mg1g",
-        "tags": [
-            "AWS",
-            "Amazon Web Services",
-            "Cloud",
-            "cloud computing",
-            "AWS Cloud",
-            "SSO",
-            "Control Tower",
-            "Access"
-        ],
-        "title": "Provisioning Users in AWS Control Tower Using AWS SSO",
-        "description": "Learn more about AWS Management and Governance at https://amzn.to/2roeilr\nIn this video, you’ll see how to provision users in AWS Control Tower using AWS Single Sign-On (or SSO). With Control Tower, you can create users using preconfigured groups, manage account access from a centralized location, and create customized permission sets for groups and users within those accounts.",
-        "date": "2019-11-26T20:50:29Z",
-        "duration": 393
-    },
-    {
-        "service": "aws_single_sign-on",
         "videoId": "aEIqeFCcK7E",
         "tags": [
             "re:Invent 2019",


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## Description

Provisioning Users in AWS Control Tower Using AWS SSO appears twice on website (2019).

Home / Security Identity & Compliance / [Aws Single Sign On](https://awsvideocatalog.com/security_identity_&_compliance/aws_single_sign-on)

This video is already present in the JSON file at lines 113-130.

## What is the new behavior?

Removes duplicate video.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None

**Issue(s) this PR closes**: #NR
